### PR TITLE
Docker installation breaks with error: symfony/runtime contains a Composer plugin which is blocked by your allow-plugins config

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 FROM composer:2.7
 RUN composer --version
+RUN composer config --global allow-plugins.symfony/runtime true
 RUN composer req undpaul/toggl2redmine
 WORKDIR /app/vendor/undpaul/toggl2redmine
 ENTRYPOINT ["./toggl2redmine"]


### PR DESCRIPTION
The docker installation is not working, since the package **symfony/runtime** is not in the global allowed plugins list while trying to install. 

This can be easily fixed by adding it to the global config, like done in the PR. 